### PR TITLE
Improve French voice selection for speech synthesis

### DIFF
--- a/app.js
+++ b/app.js
@@ -192,8 +192,7 @@
   const importBtn=document.getElementById('importBtn');
 
   let currentLesson=null,curVariantIndex=0,i=0,teacherMode=false,frenchVoice=null;
-
-  function selectFrenchVoice(){frenchVoice=speechSynthesis.getVoices().find(v=>v.lang&&v.lang.startsWith('fr'))||null}
+  function selectFrenchVoice(){const voices=speechSynthesis.getVoices().filter(v=>v.lang&&v.lang.startsWith('fr'));frenchVoice=voices.find(v=>/(Siri|Enhanced|Premium)/i.test(v.name||'')||/(Siri|Enhanced|Premium)/i.test(v.voiceURI||''))||voices[0]||null}
   selectFrenchVoice();
   speechSynthesis.addEventListener('voiceschanged',selectFrenchVoice);
 


### PR DESCRIPTION
## Summary
- Select first Siri/Enhanced/Premium French voice when available
- Fallback to first French voice
- Re-run voice selection when voices change

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b35cf008608321ae7d8cba5fdd6271